### PR TITLE
Create Next.js app for vendor risk rating

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+node_modules/
+.next/
+out/
+.DS_Store
+.env.local
+.env.development
+.env.production
+__pycache__/
+*.py[cod]

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,16 @@
+:root {
+  color-scheme: light;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+body {
+  margin: 0;
+}
+
+a {
+  color: inherit;
+}
+
+* {
+  box-sizing: border-box;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,34 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+import "./globals.css";
+
+export const metadata: Metadata = {
+  title: "Vendor Risk Rating Assistant",
+  description:
+    "Evaluate vendor analyst notes against policy-driven safeguards to determine risk ratings."
+};
+
+export default function RootLayout({
+  children
+}: {
+  children: ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body className="bg-slate-100 text-slate-900">
+        <div className="mx-auto max-w-5xl px-4 py-10">
+          <header className="mb-8 space-y-2">
+            <h1 className="text-3xl font-bold text-slate-900">
+              Vendor Risk Rating Assistant
+            </h1>
+            <p className="text-slate-600">
+              Paste analyst notes to see how the vendor maps to the policy catalog and
+              determine the resulting risk rating.
+            </p>
+          </header>
+          <main>{children}</main>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,19 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import RiskEvaluator from "../components/RiskEvaluator";
+
+async function loadSampleNotes(): Promise<string> {
+  const samplePath = path.join(process.cwd(), "sample_notes.txt");
+  try {
+    const file = await fs.readFile(samplePath, "utf-8");
+    return file.trim();
+  } catch (error) {
+    console.warn("Sample notes could not be loaded:", error);
+    return "";
+  }
+}
+
+export default async function HomePage() {
+  const sampleNotes = await loadSampleNotes();
+  return <RiskEvaluator initialNotes={sampleNotes} />;
+}

--- a/components/RiskEvaluator.tsx
+++ b/components/RiskEvaluator.tsx
@@ -1,0 +1,203 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { useMemo, useState } from "react";
+import { evaluateNotes, EvaluationResult } from "../lib/evaluator";
+
+type RiskEvaluatorProps = {
+  initialNotes?: string;
+};
+
+const ratingLabels: Record<string, string> = {
+  very_favorable: "Very Favorable",
+  favorable: "Favorable",
+  neutral: "Neutral",
+  unfavorable: "Unfavorable",
+  very_unfavorable: "Very Unfavorable",
+  n_a: "Not Applicable",
+  no_information_provided: "No Information Provided"
+};
+
+const badgeClassNames: Record<string, string> = {
+  very_favorable: "bg-emerald-100 text-emerald-900 border-emerald-200",
+  favorable: "bg-green-100 text-green-900 border-green-200",
+  neutral: "bg-slate-100 text-slate-900 border-slate-200",
+  unfavorable: "bg-amber-100 text-amber-900 border-amber-200",
+  very_unfavorable: "bg-red-100 text-red-900 border-red-200",
+  n_a: "bg-blue-100 text-blue-900 border-blue-200",
+  no_information_provided: "bg-gray-100 text-gray-900 border-gray-200"
+};
+
+const SectionTitle = ({ children }: { children: ReactNode }) => (
+  <h2 className="text-lg font-semibold text-slate-800 mb-2">{children}</h2>
+);
+
+const Section = ({ children }: { children: ReactNode }) => (
+  <section className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm">
+    {children}
+  </section>
+);
+
+const DescriptionList = ({
+  title,
+  items
+}: {
+  title: string;
+  items: string[];
+}) => (
+  <div>
+    <h3 className="font-medium text-slate-700 mb-1">{title}</h3>
+    {items.length ? (
+      <ul className="list-disc list-inside text-sm text-slate-600 space-y-1">
+        {items.map((item) => (
+          <li key={item}>{item}</li>
+        ))}
+      </ul>
+    ) : (
+      <p className="text-sm text-slate-500">None</p>
+    )}
+  </div>
+);
+
+const formatMultiline = (text: string) => text.replace(/\r?\n/g, "\n");
+
+export default function RiskEvaluator({ initialNotes = "" }: RiskEvaluatorProps) {
+  const [notes, setNotes] = useState(formatMultiline(initialNotes));
+  const [result, setResult] = useState<EvaluationResult | null>(() =>
+    initialNotes ? evaluateNotes(initialNotes) : null
+  );
+
+  const handleEvaluate = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setResult(evaluateNotes(notes));
+  };
+
+  const handleReset = () => {
+    setNotes(initialNotes ?? "");
+    setResult(initialNotes ? evaluateNotes(initialNotes) : null);
+  };
+
+  const summary = useMemo(() => {
+    if (!result) {
+      return null;
+    }
+    const label = ratingLabels[result.rating];
+    const badgeClass = badgeClassNames[result.rating] ?? badgeClassNames.neutral;
+    return (
+      <div className="flex flex-col gap-4">
+        <div className={`inline-flex items-center gap-2 rounded-full border px-4 py-2 text-sm font-semibold ${badgeClass}`}>
+          <span>Rating:</span>
+          <span>{label}</span>
+        </div>
+        <div className="grid gap-4 sm:grid-cols-2">
+          <Section>
+            <SectionTitle>Context</SectionTitle>
+            <dl className="space-y-2 text-sm text-slate-600">
+              <div className="flex justify-between">
+                <dt>Handles PII</dt>
+                <dd className="font-medium text-slate-900">
+                  {result.context.handlesPii ? "Yes" : "No"}
+                </dd>
+              </div>
+              <div className="flex justify-between">
+                <dt>Remote Work Allowed</dt>
+                <dd className="font-medium text-slate-900">
+                  {result.context.remoteWorkAllowed ? "Yes" : "No"}
+                </dd>
+              </div>
+              <div className="flex justify-between">
+                <dt>Software Provider</dt>
+                <dd className="font-medium text-slate-900">
+                  {result.context.softwareProvider ? "Yes" : "No"}
+                </dd>
+              </div>
+              <div>
+                <dt className="text-slate-700 font-medium">Incident Response Elements</dt>
+                {result.context.incidentElements.length ? (
+                  <ul className="list-disc list-inside text-slate-600">
+                    {result.context.incidentElements.map((element) => (
+                      <li key={element}>{element}</li>
+                    ))}
+                  </ul>
+                ) : (
+                  <p className="text-slate-500">None detected</p>
+                )}
+              </div>
+            </dl>
+          </Section>
+          <Section>
+            <SectionTitle>Details</SectionTitle>
+            {result.details ? (
+              <div className="space-y-3">
+                {result.details.reason && (
+                  <p className="text-sm text-slate-600">{result.details.reason}</p>
+                )}
+                {result.details.satisfiedControls && (
+                  <DescriptionList
+                    title="Satisfied Controls"
+                    items={result.details.satisfiedControls}
+                  />
+                )}
+                <DescriptionList
+                  title="Missing Controls"
+                  items={result.details.missingControls ?? []}
+                />
+                {result.details.infoTechOverview && (
+                  <DescriptionList
+                    title="Info Tech Overview"
+                    items={result.details.infoTechOverview}
+                  />
+                )}
+                {result.details.incidentResponseElements && (
+                  <DescriptionList
+                    title="Incident Response Elements"
+                    items={result.details.incidentResponseElements}
+                  />
+                )}
+              </div>
+            ) : (
+              <p className="text-sm text-slate-500">
+                No additional control details for this rating.
+              </p>
+            )}
+          </Section>
+        </div>
+      </div>
+    );
+  }, [result]);
+
+  return (
+    <div className="space-y-6">
+      <form onSubmit={handleEvaluate} className="space-y-4">
+        <div className="space-y-2">
+          <label htmlFor="notes" className="text-sm font-medium text-slate-700">
+            Analyst Notes
+          </label>
+          <textarea
+            id="notes"
+            className="w-full min-h-[220px] resize-y rounded-lg border border-slate-300 p-3 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+            value={notes}
+            onChange={(event) => setNotes(event.target.value)}
+            placeholder="Paste analyst notes here..."
+          />
+        </div>
+        <div className="flex flex-wrap gap-3">
+          <button
+            type="submit"
+            className="inline-flex items-center justify-center rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-400"
+          >
+            Evaluate Vendor
+          </button>
+          <button
+            type="button"
+            onClick={handleReset}
+            className="inline-flex items-center justify-center rounded-lg border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-slate-200"
+          >
+            Reset to Sample
+          </button>
+        </div>
+      </form>
+      {summary}
+    </div>
+  );
+}

--- a/lib/evaluator.ts
+++ b/lib/evaluator.ts
@@ -1,0 +1,514 @@
+import ratingRules from "../rules/rating_rules.json";
+
+export type RatingLevel =
+  | "very_favorable"
+  | "favorable"
+  | "neutral"
+  | "unfavorable"
+  | "very_unfavorable"
+  | "n_a"
+  | "no_information_provided";
+
+export interface EvaluationDetails {
+  rating?: Exclude<RatingLevel, "very_unfavorable" | "n_a" | "no_information_provided">;
+  satisfiedControls?: string[];
+  missingControls: string[];
+  incidentResponseElements?: string[];
+  infoTechOverview?: string[];
+  reason?: string;
+}
+
+export interface EvaluationContext {
+  handlesPii: boolean;
+  remoteWorkAllowed: boolean;
+  softwareProvider: boolean;
+  incidentElements: string[];
+}
+
+export interface EvaluationResult {
+  rating: RatingLevel;
+  details: EvaluationDetails | null;
+  context: EvaluationContext;
+}
+
+type ControlStatus = {
+  controlId: string;
+  required: boolean;
+  satisfied: boolean;
+  text: string;
+  tags: string[];
+};
+
+type ControlStatusMap = Record<string, ControlStatus>;
+
+type Rules = typeof ratingRules;
+
+type CrossSatisfactionRule = Rules["conditions"]["cross_satisfaction"][number];
+
+const SOFTWARE_PROVIDER_KEYWORDS = [
+  "software provider",
+  "software development",
+  "develops software",
+  "developing software",
+  "builds software",
+  "provides software",
+  "saas",
+  "platform as a service",
+  "application development"
+];
+
+const normalize = (text: string): string =>
+  text
+    .toLowerCase()
+    .replace(/…/g, "...")
+    .replace(/\s+/g, " ")
+    .trim();
+
+const statementPresent = (notes: string, statement: string): boolean => {
+  if (!statement) {
+    return false;
+  }
+  const normalizedStatement = normalize(statement);
+  return normalizedStatement.length > 0 && notes.includes(normalizedStatement);
+};
+
+const buildContext = (notes: string, rules: Rules) => {
+  const logicalConditions = rules.conditions.logical_access_controls ?? {};
+  const handlesPii = Boolean(
+    logicalConditions.pii_positive_statements?.some((statement) =>
+      statementPresent(notes, statement)
+    )
+  );
+
+  const remoteCondition = rules.conditions.remote_workforce?.enforce_only_if_remote_work_allowed ?? "";
+  const remoteWorkAllowed = Boolean(remoteCondition) && statementPresent(notes, remoteCondition);
+
+  const softwareProvider = SOFTWARE_PROVIDER_KEYWORDS.some((phrase) =>
+    notes.includes(phrase)
+  );
+
+  return { handlesPii, remoteWorkAllowed, softwareProvider };
+};
+
+const applyCrossSatisfaction = (notes: string, rules: Rules): Set<string> => {
+  const satisfied = new Set<string>();
+  const crossRules = rules.conditions.cross_satisfaction ?? [];
+  crossRules.forEach((rule: CrossSatisfactionRule) => {
+    const triggerStatements = rule.if_any_statement_present ?? [];
+    if (
+      triggerStatements.some((statement) => statementPresent(notes, statement))
+    ) {
+      rule.then_mark_controls_met?.forEach((controlId) => satisfied.add(controlId));
+    }
+  });
+  return satisfied;
+};
+
+const statementSatisfiesControl = (
+  notes: string,
+  controlId: string,
+  controlText: string,
+  rules: Rules
+): boolean => {
+  if (statementPresent(notes, controlText)) {
+    return true;
+  }
+  if (controlId && notes.includes(controlId)) {
+    return true;
+  }
+  const words = controlId.split(/\W+/).filter(Boolean);
+  if (words.length > 1) {
+    const token = words.slice(1).join(" ");
+    if (token && notes.includes(token)) {
+      return true;
+    }
+  }
+
+  if (controlId === "lac_passwords_encrypted_in_transit") {
+    const negatives =
+      rules.conditions.logical_access_controls
+        ?.passwords_encrypted_in_transit_only_if_negative_statement_present ?? [];
+    if (negatives.some((statement) => statementPresent(notes, statement))) {
+      return false;
+    }
+  }
+
+  return false;
+};
+
+const registerControl = (
+  status: ControlStatusMap,
+  controlId: string,
+  required: boolean,
+  satisfied: boolean,
+  text: string,
+  tags: string[]
+) => {
+  status[controlId] = { controlId, required, satisfied, text, tags };
+};
+
+const evaluateControls = (
+  notes: string,
+  rules: Rules,
+  context: ReturnType<typeof buildContext>,
+  crossSatisfied: Set<string>
+): ControlStatusMap => {
+  const status: ControlStatusMap = {};
+  const catalog = rules.catalog ?? {};
+  const conditions = rules.conditions ?? {};
+
+  const checkControl = (control: any, required: boolean = true) => {
+    const controlId = control.id as string;
+    const controlText = (control.text ?? "") as string;
+    const tags = (control.tags ?? []) as string[];
+    const satisfied = crossSatisfied.has(controlId)
+      ? true
+      : statementSatisfiesControl(notes, controlId, controlText, rules);
+    registerControl(status, controlId, required, satisfied, controlText, tags);
+  };
+
+  catalog.logical_access_controls?.forEach((control: any) => {
+    let required = true;
+    if (
+      control.id === "lac_mfa_critical_or_pii" &&
+      conditions.logical_access_controls?.enforce_mfa_critical_or_pii_if_company_handles_pii &&
+      !context.handlesPii
+    ) {
+      required = false;
+    }
+    checkControl(control, required);
+  });
+
+  const networkCatalog = catalog.network_information_security ?? {};
+
+  networkCatalog.pii_controls?.forEach((control: any) => {
+    let required = true;
+    if (
+      conditions.network_information_security?.enforce_pii_controls_if_company_handles_pii &&
+      !context.handlesPii
+    ) {
+      required = false;
+    }
+    if (
+      control.id === "net_pii_need_to_know" &&
+      conditions.network_information_security?.do_not_enforce_need_to_know_if_least_privilege_statement_present
+    ) {
+      const leastPrivilege = status["lac_least_privilege"];
+      if (leastPrivilege?.satisfied) {
+        registerControl(status, control.id, false, true, control.text ?? "", control.tags ?? []);
+        return;
+      }
+    }
+    checkControl(control, required);
+  });
+
+  networkCatalog.controls?.forEach((control: any) => {
+    checkControl(control, true);
+  });
+
+  catalog.change_mgmt_sdlc?.forEach((control: any) => {
+    const required = context.softwareProvider;
+    checkControl(control, required);
+  });
+
+  catalog.remote_workforce?.forEach((control: any) => {
+    const required = context.remoteWorkAllowed;
+    checkControl(control, required);
+  });
+
+  catalog.business_continuity?.forEach((control: any) => {
+    checkControl(control, true);
+  });
+
+  return status;
+};
+
+const collectIncidentResponseElements = (
+  notes: string,
+  rules: Rules
+): Set<string> => {
+  const elements = new Set<string>();
+  rules.catalog.incident_response_elements?.forEach((element) => {
+    if (statementPresent(notes, element)) {
+      elements.add(element);
+    }
+  });
+  return elements;
+};
+
+const evaluateInfoTechOverview = (notes: string, rules: Rules): Set<string> => {
+  const required =
+    rules.ratings.very_favorable.info_tech_overview?.required ?? [];
+  const present = new Set<string>();
+  required.forEach((statement) => {
+    if (statementPresent(notes, statement)) {
+      present.add(statement);
+    }
+  });
+  return present;
+};
+
+const evaluateBusinessContinuity = (status: ControlStatusMap): boolean => {
+  const bcpControl = status["bcp_plan"];
+  return Boolean(bcpControl?.satisfied);
+};
+
+const categoryControls = (
+  prefix: string,
+  status: ControlStatusMap
+): ControlStatus[] => Object.values(status).filter((ctrl) => ctrl.controlId.startsWith(prefix));
+
+const meetsInfoTechOverview = (requirement: any, present: Set<string>): boolean => {
+  const required = requirement?.required ?? [];
+  return required.every((statement: string) => present.has(statement));
+};
+
+const meetsLogicalAccessControls = (requirement: any, status: ControlStatusMap): boolean => {
+  const controls = categoryControls("lac_", status).filter((ctrl) => ctrl.required);
+  if (requirement?.required_all) {
+    return controls.every((ctrl) => ctrl.satisfied);
+  }
+  const count = controls.filter((ctrl) => ctrl.satisfied).length;
+  if (count < (requirement?.min_count ?? 0)) {
+    return false;
+  }
+  const tag = requirement?.must_include_tag as string | undefined;
+  if (tag) {
+    const hasTagged = controls.some((ctrl) => ctrl.satisfied && ctrl.tags.includes(tag));
+    if (!hasTagged) {
+      return false;
+    }
+  }
+  return true;
+};
+
+const meetsNetworkControls = (
+  requirement: any,
+  context: ReturnType<typeof buildContext>,
+  status: ControlStatusMap
+): boolean => {
+  const piiControls = categoryControls("net_pii_", status).filter((ctrl) => ctrl.required);
+  if (requirement?.pii_controls_required_if_company_handles_pii && context.handlesPii) {
+    if (!piiControls.length || piiControls.some((ctrl) => !ctrl.satisfied)) {
+      return false;
+    }
+  }
+  const netControls = Object.values(status).filter(
+    (ctrl) => ctrl.controlId.startsWith("net_") && !ctrl.controlId.startsWith("net_pii_")
+  );
+  const requiredControls = netControls.filter((ctrl) => ctrl.required);
+  if (requirement?.controls_required_all) {
+    return requiredControls.every((ctrl) => ctrl.satisfied);
+  }
+  const count = requiredControls.filter((ctrl) => ctrl.satisfied).length;
+  if (count < (requirement?.min_count ?? 0)) {
+    return false;
+  }
+  const tag = requirement?.must_include_tag as string | undefined;
+  if (tag) {
+    const hasTagged = requiredControls.some(
+      (ctrl) => ctrl.satisfied && ctrl.tags.includes(tag)
+    );
+    if (!hasTagged) {
+      return false;
+    }
+  }
+  return true;
+};
+
+const meetsChangeMgmt = (
+  requirement: any,
+  context: ReturnType<typeof buildContext>,
+  status: ControlStatusMap
+): boolean => {
+  const controls = categoryControls("chg_", status).filter((ctrl) => ctrl.required);
+  if (!context.softwareProvider) {
+    return true;
+  }
+  if (requirement?.required_all) {
+    return controls.every((ctrl) => ctrl.satisfied);
+  }
+  if (requirement?.require_change_mgmt_process) {
+    const changeMgmt = status["chg_change_mgmt_process"];
+    if (!changeMgmt?.satisfied) {
+      return false;
+    }
+  }
+  const minCountFrom = requirement?.min_count_from as string[] | undefined;
+  if (minCountFrom?.length) {
+    const satisfiedCount = minCountFrom.reduce((count, controlId) => {
+      const control = status[controlId];
+      return control?.satisfied ? count + 1 : count;
+    }, 0);
+    return satisfiedCount >= (requirement?.min_count ?? 0);
+  }
+  const count = controls.filter((ctrl) => ctrl.satisfied).length;
+  return count >= (requirement?.min_count ?? 0);
+};
+
+const meetsRemoteWorkforce = (
+  requirement: any,
+  context: ReturnType<typeof buildContext>,
+  status: ControlStatusMap
+): boolean => {
+  const controls = categoryControls("rw_", status).filter((ctrl) => ctrl.required);
+  if (!context.remoteWorkAllowed) {
+    return true;
+  }
+  if (requirement?.required_all) {
+    return controls.every((ctrl) => ctrl.satisfied);
+  }
+  const count = controls.filter((ctrl) => ctrl.satisfied).length;
+  return count >= (requirement?.min_count ?? 0);
+};
+
+const meetsIncidentResponse = (requirement: any, elements: Set<string>): boolean => {
+  const minElements = requirement?.min_elements;
+  if (typeof minElements !== "number") {
+    return true;
+  }
+  return elements.size >= minElements;
+};
+
+const meetsBusinessContinuity = (requirement: any, hasPlan: boolean): boolean => {
+  if (!requirement) {
+    return true;
+  }
+  if (requirement.required && !hasPlan) {
+    return false;
+  }
+  return true;
+};
+
+const missingRequiredControls = (status: ControlStatusMap): string[] => {
+  return Object.values(status)
+    .filter((ctrl) => ctrl.required && !ctrl.satisfied)
+    .map((ctrl) => ctrl.controlId)
+    .sort();
+};
+
+const buildRatingDetails = (
+  rating: Exclude<RatingLevel, "very_unfavorable" | "n_a" | "no_information_provided">,
+  status: ControlStatusMap,
+  incidentElements: Set<string>,
+  infoTechOverview: Set<string>
+): EvaluationDetails => ({
+  rating,
+  satisfiedControls: Object.values(status)
+    .filter((ctrl) => ctrl.required && ctrl.satisfied)
+    .map((ctrl) => ctrl.controlId)
+    .sort(),
+  missingControls: missingRequiredControls(status),
+  incidentResponseElements: Array.from(incidentElements).sort(),
+  infoTechOverview: Array.from(infoTechOverview).sort()
+});
+
+const determineRating = (
+  rules: Rules,
+  context: ReturnType<typeof buildContext>,
+  status: ControlStatusMap,
+  incidentElements: Set<string>,
+  infoTechOverview: Set<string>,
+  businessContinuity: boolean
+): { rating: RatingLevel; details: EvaluationDetails | null } => {
+  const ratingsOrder: Exclude<RatingLevel, "very_unfavorable" | "n_a" | "no_information_provided">[] = [
+    "very_favorable",
+    "favorable",
+    "neutral",
+    "unfavorable"
+  ];
+
+  for (const rating of ratingsOrder) {
+    const requirements = (rules.ratings as any)[rating];
+    if (
+      meetsInfoTechOverview(requirements.info_tech_overview, infoTechOverview) &&
+      meetsLogicalAccessControls(requirements.logical_access_controls, status) &&
+      meetsNetworkControls(requirements.network_information_security, context, status) &&
+      meetsChangeMgmt(requirements.change_mgmt_sdlc, context, status) &&
+      meetsRemoteWorkforce(requirements.remote_workforce, context, status) &&
+      meetsIncidentResponse(requirements.incident_response, incidentElements) &&
+      meetsBusinessContinuity(requirements.business_continuity, businessContinuity)
+    ) {
+      return {
+        rating,
+        details: buildRatingDetails(rating, status, incidentElements, infoTechOverview)
+      };
+    }
+  }
+
+  return {
+    rating: "very_unfavorable",
+    details: {
+      missingControls: missingRequiredControls(status),
+      reason:
+        "Vendor did not satisfy the minimum safeguards for an unfavorable rating."
+    }
+  };
+};
+
+export const evaluateNotes = (rawNotes: string): EvaluationResult => {
+  const normalizedNotes = normalize(rawNotes ?? "");
+  if (!normalizedNotes) {
+    return {
+      rating: "no_information_provided",
+      details: null,
+      context: {
+        handlesPii: false,
+        remoteWorkAllowed: false,
+        softwareProvider: false,
+        incidentElements: []
+      }
+    };
+  }
+
+  if (
+    normalizedNotes.includes("not applicable") ||
+    /\bn\/a\b/.test(normalizedNotes)
+  ) {
+    return {
+      rating: "n_a",
+      details: null,
+      context: {
+        handlesPii: false,
+        remoteWorkAllowed: false,
+        softwareProvider: false,
+        incidentElements: []
+      }
+    };
+  }
+
+  const context = buildContext(normalizedNotes, ratingRules);
+  const crossSatisfied = applyCrossSatisfaction(normalizedNotes, ratingRules);
+  const controlStatus = evaluateControls(
+    normalizedNotes,
+    ratingRules,
+    context,
+    crossSatisfied
+  );
+  const incidentElements = collectIncidentResponseElements(
+    normalizedNotes,
+    ratingRules
+  );
+  const infoTechOverview = evaluateInfoTechOverview(normalizedNotes, ratingRules);
+  const businessContinuity = evaluateBusinessContinuity(controlStatus);
+
+  const { rating, details } = determineRating(
+    ratingRules,
+    context,
+    controlStatus,
+    incidentElements,
+    infoTechOverview,
+    businessContinuity
+  );
+
+  return {
+    rating,
+    details,
+    context: {
+      handlesPii: context.handlesPii,
+      remoteWorkAllowed: context.remoteWorkAllowed,
+      softwareProvider: context.softwareProvider,
+      incidentElements: Array.from(incidentElements).sort()
+    }
+  };
+};

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true
+};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "risk-rating-assistant",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.1.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "20.11.30",
+    "@types/react": "18.2.21",
+    "@types/react-dom": "18.2.7",
+    "eslint": "8.56.0",
+    "eslint-config-next": "14.1.0",
+    "typescript": "5.3.3"
+  }
+}

--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,36 @@
+# Risk Rating Assistant
+
+A React/Next.js application that evaluates vendor risk ratings from analyst notes using the policy and procedure catalog defined in `rules/rating_rules.json`.
+
+## Getting started
+
+1. Install dependencies:
+
+   ```bash
+   npm install
+   ```
+
+2. Run the development server:
+
+   ```bash
+   npm run dev
+   ```
+
+3. Open http://localhost:3000 in your browser. Paste analyst notes into the text area and click **Evaluate Vendor** to compute the risk rating.
+
+The page loads with the sample notes from `sample_notes.txt` so you can see a fully satisfied example immediately.
+
+## Project structure
+
+- `app/` – Next.js app router pages and global layout/styles.
+- `components/` – UI components, including the interactive risk evaluator.
+- `lib/evaluator.ts` – TypeScript implementation of the policy-driven risk evaluation engine.
+- `rules/rating_rules.json` – Source catalog with all controls, conditions, and rating thresholds.
+- `sample_notes.txt` – Example analyst notes demonstrating a comprehensive submission.
+
+## Scripts
+
+- `npm run dev` – Start the development server with hot reloading.
+- `npm run build` – Create an optimized production build.
+- `npm run start` – Run the production build locally.
+- `npm run lint` – Run Next.js ESLint checks.

--- a/risk_rating/__init__.py
+++ b/risk_rating/__init__.py
@@ -1,0 +1,5 @@
+"""Risk rating evaluation package."""
+
+from .analyzer import RiskRatingEvaluator, load_rules
+
+__all__ = ["RiskRatingEvaluator", "load_rules"]

--- a/risk_rating/__main__.py
+++ b/risk_rating/__main__.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from .analyzer import RiskRatingEvaluator, load_rules
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Determine vendor risk rating from analyst notes.")
+    parser.add_argument("notes", help="Path to a text file containing analyst notes or raw text.")
+    parser.add_argument(
+        "--rules",
+        type=Path,
+        default=Path(__file__).resolve().parent.parent / "rules" / "rating_rules.json",
+        help="Path to the rating rules JSON file.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Optional path to write the evaluation result as JSON.",
+    )
+    return parser.parse_args()
+
+
+def load_notes(notes_arg: str) -> str:
+    path = Path(notes_arg)
+    if path.exists():
+        return path.read_text(encoding="utf-8")
+    return notes_arg
+
+
+def main() -> None:
+    args = parse_args()
+    notes = load_notes(args.notes)
+    rules_path = args.rules
+    if not rules_path.exists():
+        default_rules = Path(__file__).resolve().parent.parent / "rules" / "rating_rules.json"
+        rules_path = default_rules
+    rules = load_rules(rules_path)
+    evaluator = RiskRatingEvaluator(rules)
+    result = evaluator.evaluate(notes)
+    output = json.dumps(result, indent=2)
+    if args.output:
+        args.output.write_text(output, encoding="utf-8")
+    print(output)
+
+
+if __name__ == "__main__":
+    main()

--- a/risk_rating/analyzer.py
+++ b/risk_rating/analyzer.py
@@ -1,0 +1,480 @@
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Sequence, Set, Tuple
+
+
+def load_rules(path: Path | str) -> dict:
+    """Load the rules JSON file."""
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _normalize(text: str) -> str:
+    normalized = text.lower().replace("…", "...")
+    return re.sub(r"\s+", " ", normalized).strip()
+
+
+def _statement_present(notes: str, statement: str) -> bool:
+    if not statement:
+        return False
+    normalized_statement = _normalize(statement)
+    return normalized_statement in notes
+
+
+@dataclass
+class ControlStatus:
+    control_id: str
+    required: bool
+    satisfied: bool
+    text: str
+    tags: Sequence[str]
+
+
+class RiskRatingEvaluator:
+    """Evaluate vendor risk using analyst notes."""
+
+    SOFTWARE_PROVIDER_KEYWORDS = [
+        "software provider",
+        "software development",
+        "develops software",
+        "developing software",
+        "builds software",
+        "provides software",
+        "saas",
+        "platform as a service",
+        "application development",
+    ]
+
+    def __init__(self, rules: dict):
+        self.rules = rules
+        self.notes: str = ""
+
+    @classmethod
+    def from_path(cls, path: Path | str) -> "RiskRatingEvaluator":
+        return cls(load_rules(path))
+
+    def evaluate(self, notes: str) -> dict:
+        self.notes = _normalize(notes)
+        if not self.notes:
+            return {
+                "rating": "no_information_provided",
+                "details": {},
+                "context": {
+                    "handles_pii": False,
+                    "remote_work_allowed": False,
+                    "software_provider": False,
+                },
+            }
+
+        if "not applicable" in self.notes or re.search(r"\bn/a\b", self.notes):
+            return {
+                "rating": "n_a",
+                "details": {},
+                "context": {
+                    "handles_pii": False,
+                    "remote_work_allowed": False,
+                    "software_provider": False,
+                },
+            }
+
+        context = self._build_context()
+        cross_satisfied = self._apply_cross_satisfaction()
+        control_status = self._evaluate_controls(context, cross_satisfied)
+        incident_elements = self._collect_incident_response_elements()
+        info_tech_overview = self._evaluate_info_tech_overview()
+        business_continuity = self._evaluate_business_continuity(control_status)
+
+        rating, rating_details = self._determine_rating(
+            context,
+            control_status,
+            incident_elements,
+            info_tech_overview,
+            business_continuity,
+        )
+
+        return {
+            "rating": rating,
+            "details": rating_details,
+            "context": {
+                "handles_pii": context["handles_pii"],
+                "remote_work_allowed": context["remote_work_allowed"],
+                "software_provider": context["software_provider"],
+                "incident_elements": sorted(incident_elements),
+            },
+        }
+
+    def _build_context(self) -> Dict[str, bool]:
+        logical_conditions = self.rules["conditions"].get("logical_access_controls", {})
+        handles_pii = any(
+            _statement_present(self.notes, stmt)
+            for stmt in logical_conditions.get("pii_positive_statements", [])
+        )
+
+        remote_condition = (
+            self.rules["conditions"].get("remote_workforce", {}).get(
+                "enforce_only_if_remote_work_allowed", ""
+            )
+        )
+        remote_allowed = bool(remote_condition) and _statement_present(
+            self.notes, remote_condition
+        )
+
+        software_provider = any(
+            phrase in self.notes for phrase in self.SOFTWARE_PROVIDER_KEYWORDS
+        )
+
+        return {
+            "handles_pii": handles_pii,
+            "remote_work_allowed": remote_allowed,
+            "software_provider": software_provider,
+        }
+
+    def _apply_cross_satisfaction(self) -> Set[str]:
+        cross_rules = self.rules["conditions"].get("cross_satisfaction", [])
+        satisfied: Set[str] = set()
+        for rule in cross_rules:
+            if_any = rule.get("if_any_statement_present", [])
+            for statement in if_any:
+                if _statement_present(self.notes, statement):
+                    satisfied.update(rule.get("then_mark_controls_met", []))
+                    break
+        return satisfied
+
+    def _evaluate_controls(
+        self, context: Dict[str, bool], cross_satisfied: Set[str]
+    ) -> Dict[str, ControlStatus]:
+        status: Dict[str, ControlStatus] = {}
+        conditions = self.rules.get("conditions", {})
+
+        def register_control(control_id: str, required: bool, satisfied: bool, text: str, tags: Sequence[str]) -> None:
+            status[control_id] = ControlStatus(
+                control_id=control_id,
+                required=required,
+                satisfied=satisfied,
+                text=text,
+                tags=tags,
+            )
+
+        def check_control(control: dict, required: bool = True) -> None:
+            control_id = control["id"]
+            control_text = control.get("text", "")
+            satisfied = False
+            if control_id in cross_satisfied:
+                satisfied = True
+            else:
+                satisfied = self._statement_satisfies_control(control_id, control_text)
+            register_control(control_id, required, satisfied, control_text, control.get("tags", []))
+
+        catalog = self.rules.get("catalog", {})
+
+        for control in catalog.get("logical_access_controls", []):
+            required = True
+            if (
+                control["id"] == "lac_mfa_critical_or_pii"
+                and conditions.get("logical_access_controls", {}).get(
+                    "enforce_mfa_critical_or_pii_if_company_handles_pii", False
+                )
+                and not context["handles_pii"]
+            ):
+                required = False
+            check_control(control, required)
+
+        network_catalog = catalog.get("network_information_security", {})
+        for control in network_catalog.get("pii_controls", []):
+            required = not (
+                conditions.get("network_information_security", {}).get(
+                    "enforce_pii_controls_if_company_handles_pii", False
+                )
+                and not context["handles_pii"]
+            )
+            if (
+                control["id"] == "net_pii_need_to_know"
+                and conditions.get("network_information_security", {}).get(
+                    "do_not_enforce_need_to_know_if_least_privilege_statement_present", False
+                )
+            ):
+                least_privilege = status.get("lac_least_privilege")
+                if least_privilege and least_privilege.satisfied:
+                    register_control(
+                        control["id"],
+                        required=False,
+                        satisfied=True,
+                        text=control.get("text", ""),
+                        tags=control.get("tags", []),
+                    )
+                    continue
+            check_control(control, required)
+
+        for control in network_catalog.get("controls", []):
+            check_control(control, required=True)
+
+        for control in catalog.get("change_mgmt_sdlc", []):
+            required = context["software_provider"]
+            check_control(control, required)
+
+        for control in catalog.get("remote_workforce", []):
+            required = context["remote_work_allowed"]
+            check_control(control, required)
+
+        for control in catalog.get("business_continuity", []):
+            check_control(control, required=True)
+
+        return status
+
+    def _statement_satisfies_control(self, control_id: str, control_text: str) -> bool:
+        if _statement_present(self.notes, control_text):
+            return True
+        if control_id and control_id in self.notes:
+            return True
+        words = re.split(r"\W+", control_id)
+        if len(words) > 1:
+            # Ensure acronym-like tokens also work
+            token = " ".join(words[1:])
+            if token and token in self.notes:
+                return True
+        # Handle negative statements overriding positives
+        if control_id == "lac_passwords_encrypted_in_transit":
+            negatives = self.rules["conditions"]["logical_access_controls"].get(
+                "passwords_encrypted_in_transit_only_if_negative_statement_present", []
+            )
+            if any(_statement_present(self.notes, neg) for neg in negatives):
+                return False
+        return False
+
+    def _collect_incident_response_elements(self) -> Set[str]:
+        elements = set()
+        for element in self.rules["catalog"].get("incident_response_elements", []):
+            if _statement_present(self.notes, element):
+                elements.add(element)
+        return elements
+
+    def _evaluate_info_tech_overview(self) -> Set[str]:
+        required = self.rules["ratings"]["very_favorable"]["info_tech_overview"].get("required", [])
+        present = set()
+        for statement in required:
+            if _statement_present(self.notes, statement):
+                present.add(statement)
+        return present
+
+    def _evaluate_business_continuity(self, control_status: Dict[str, ControlStatus]) -> bool:
+        bcp_control = control_status.get("bcp_plan")
+        return bool(bcp_control and bcp_control.satisfied)
+
+    def _determine_rating(
+        self,
+        context: Dict[str, bool],
+        control_status: Dict[str, ControlStatus],
+        incident_elements: Set[str],
+        info_tech_overview: Set[str],
+        business_continuity: bool,
+    ) -> Tuple[str, dict]:
+        ratings_order = [
+            "very_favorable",
+            "favorable",
+            "neutral",
+            "unfavorable",
+        ]
+
+        for rating in ratings_order:
+            requirements = self.rules["ratings"][rating]
+            if self._meets_rating(
+                rating,
+                requirements,
+                context,
+                control_status,
+                incident_elements,
+                info_tech_overview,
+                business_continuity,
+            ):
+                return rating, self._build_rating_details(
+                    rating,
+                    requirements,
+                    control_status,
+                    incident_elements,
+                    info_tech_overview,
+                )
+
+        # Did not meet unfavorable: automatically very unfavorable
+        return "very_unfavorable", {
+            "reason": "Vendor did not satisfy the minimum safeguards for an unfavorable rating.",
+            "missing_controls": self._missing_required_controls(control_status),
+        }
+
+    def _meets_rating(
+        self,
+        rating: str,
+        requirements: dict,
+        context: Dict[str, bool],
+        control_status: Dict[str, ControlStatus],
+        incident_elements: Set[str],
+        info_tech_overview: Set[str],
+        business_continuity: bool,
+    ) -> bool:
+        if not self._meets_info_tech_overview(requirements.get("info_tech_overview", {}), info_tech_overview):
+            return False
+
+        if not self._meets_logical_access_controls(
+            requirements.get("logical_access_controls", {}), control_status
+        ):
+            return False
+
+        if not self._meets_network_controls(
+            requirements.get("network_information_security", {}),
+            context,
+            control_status,
+        ):
+            return False
+
+        if not self._meets_change_mgmt(
+            requirements.get("change_mgmt_sdlc", {}), context, control_status
+        ):
+            return False
+
+        if not self._meets_remote_workforce(
+            requirements.get("remote_workforce", {}), context, control_status
+        ):
+            return False
+
+        if not self._meets_incident_response(requirements.get("incident_response", {}), incident_elements):
+            return False
+
+        if not self._meets_business_continuity(requirements.get("business_continuity", {}), business_continuity):
+            return False
+
+        return True
+
+    def _meets_info_tech_overview(self, requirement: dict, present: Set[str]) -> bool:
+        required = requirement.get("required", [])
+        return all(statement in present for statement in required)
+
+    def _category_controls(self, prefix: str, status: Dict[str, ControlStatus]) -> List[ControlStatus]:
+        return [ctrl for ctrl_id, ctrl in status.items() if ctrl_id.startswith(prefix)]
+
+    def _meets_logical_access_controls(self, requirement: dict, status: Dict[str, ControlStatus]) -> bool:
+        controls = self._category_controls("lac_", status)
+        required_controls = [ctrl for ctrl in controls if ctrl.required]
+        if requirement.get("required_all"):
+            return all(ctrl.satisfied for ctrl in required_controls)
+        count = sum(1 for ctrl in required_controls if ctrl.satisfied)
+        if count < requirement.get("min_count", 0):
+            return False
+        tag = requirement.get("must_include_tag")
+        if tag:
+            if not any(ctrl.satisfied and tag in ctrl.tags for ctrl in required_controls):
+                return False
+        return True
+
+    def _meets_network_controls(
+        self,
+        requirement: dict,
+        context: Dict[str, bool],
+        status: Dict[str, ControlStatus],
+    ) -> bool:
+        pii_controls = [ctrl for ctrl in self._category_controls("net_pii_", status) if ctrl.required]
+        if requirement.get("pii_controls_required_if_company_handles_pii") and context["handles_pii"]:
+            if not pii_controls:
+                return False
+            if not all(ctrl.satisfied for ctrl in pii_controls):
+                return False
+
+        net_controls = [
+            ctrl
+            for ctrl in status.values()
+            if ctrl.control_id.startswith("net_") and not ctrl.control_id.startswith("net_pii_")
+        ]
+        required_controls = [ctrl for ctrl in net_controls if ctrl.required]
+        if requirement.get("controls_required_all"):
+            return all(ctrl.satisfied for ctrl in required_controls)
+
+        count = sum(1 for ctrl in required_controls if ctrl.satisfied)
+        if count < requirement.get("min_count", 0):
+            return False
+        tag = requirement.get("must_include_tag")
+        if tag and not any(ctrl.satisfied and tag in ctrl.tags for ctrl in required_controls):
+            return False
+        return True
+
+    def _meets_change_mgmt(self, requirement: dict, context: Dict[str, bool], status: Dict[str, ControlStatus]) -> bool:
+        controls = self._category_controls("chg_", status)
+        required_controls = [ctrl for ctrl in controls if ctrl.required]
+        if not context["software_provider"]:
+            return True
+        if requirement.get("required_all"):
+            return all(ctrl.satisfied for ctrl in required_controls)
+        if requirement.get("require_change_mgmt_process"):
+            change_mgmt = status.get("chg_change_mgmt_process")
+            if not change_mgmt or not change_mgmt.satisfied:
+                return False
+        min_count_from = requirement.get("min_count_from", [])
+        if min_count_from:
+            satisfied_count = sum(
+                1
+                for control_id in min_count_from
+                if status.get(control_id) and status[control_id].satisfied
+            )
+            if satisfied_count < requirement.get("min_count", 0):
+                return False
+        else:
+            count = sum(1 for ctrl in required_controls if ctrl.satisfied)
+            if count < requirement.get("min_count", 0):
+                return False
+        return True
+
+    def _meets_remote_workforce(
+        self,
+        requirement: dict,
+        context: Dict[str, bool],
+        status: Dict[str, ControlStatus],
+    ) -> bool:
+        controls = self._category_controls("rw_", status)
+        required_controls = [ctrl for ctrl in controls if ctrl.required]
+        if not context["remote_work_allowed"]:
+            return True
+        if requirement.get("required_all"):
+            return all(ctrl.satisfied for ctrl in required_controls)
+        count = sum(1 for ctrl in required_controls if ctrl.satisfied)
+        if count < requirement.get("min_count", 0):
+            return False
+        return True
+
+    def _meets_incident_response(self, requirement: dict, elements: Set[str]) -> bool:
+        min_elements = requirement.get("min_elements")
+        if min_elements is None:
+            return True
+        return len(elements) >= min_elements
+
+    def _meets_business_continuity(self, requirement: dict, has_plan: bool) -> bool:
+        if not requirement:
+            return True
+        if requirement.get("required") and not has_plan:
+            return False
+        return True
+
+    def _build_rating_details(
+        self,
+        rating: str,
+        requirements: dict,
+        status: Dict[str, ControlStatus],
+        incident_elements: Set[str],
+        info_tech_overview: Set[str],
+    ) -> dict:
+        details = {
+            "rating": rating,
+            "satisfied_controls": sorted(
+                ctrl.control_id for ctrl in status.values() if ctrl.satisfied and ctrl.required
+            ),
+            "missing_controls": self._missing_required_controls(status),
+            "incident_response_elements": sorted(incident_elements),
+            "info_tech_overview": sorted(info_tech_overview),
+        }
+        return details
+
+    def _missing_required_controls(self, status: Dict[str, ControlStatus]) -> List[str]:
+        missing = [ctrl.control_id for ctrl in status.values() if ctrl.required and not ctrl.satisfied]
+        missing.sort()
+        return missing
+

--- a/rules/rating_rules.json
+++ b/rules/rating_rules.json
@@ -1,0 +1,166 @@
+{
+  "version": "P&P_VendorRisk_v2025-08-18",
+  "catalog": {
+    "logical_access_controls": [
+      { "id": "lac_least_privilege", "text": "Access is provisioned… principle of least privilege", "tags": ["red"] },
+      { "id": "lac_mfa_critical_or_pii", "text": "MFA is required for access to critical systems or consumer PII", "tags": [] },
+      { "id": "lac_no_shared_credentials", "text": "Shared credentials are strictly prohibited", "tags": [] },
+      { "id": "lac_mfa_privileged", "text": "MFA is required to secure all privileged/admin accounts", "tags": [] },
+      { "id": "lac_review_annually", "text": "Access rights and privileges are reviewed at least annually", "tags": ["red"] },
+      { "id": "lac_review_on_role_change", "text": "Access rights are reviewed when an employee changes roles", "tags": ["red"] },
+      { "id": "lac_password_complexity", "text": "Passwords are unique with complexity rules", "tags": ["red"] },
+      { "id": "lac_account_lockout", "text": "Automatic account lockout occurs", "tags": [] },
+      { "id": "lac_password_rotation", "text": "Password frequency changes are required at regular intervals", "tags": [] },
+      { "id": "lac_passwords_encrypted_in_transit", "text": "Passwords must be encrypted in transit", "tags": [] },
+      { "id": "lac_mfa_factors_two_plus", "text": "At least 2 parameters used for 2FA/MFA (Passwords, Smart card, Biometrics, Certificates, One-time password devices, ID badges, Rotating authenticator apps)", "tags": [] }
+    ],
+    "network_information_security": {
+      "pii_controls": [
+        { "id": "net_pii_need_to_know", "text": "Access to consumer PII is limited based on the need to know", "tags": [] },
+        { "id": "net_pii_encrypted_in_transit", "text": "Consumer PII in transit is protected by encryption", "tags": [] },
+        { "id": "net_pii_secure_disposal", "text": "Policies and procedures require secure disposal of consumer PII", "tags": [] }
+      ],
+      "controls": [
+        { "id": "net_firewall_network_or_host", "text": "Network firewall and/or host-based firewall for workstations", "tags": ["red"] },
+        { "id": "net_dmz", "text": "Network designed with a DMZ", "tags": [] },
+        { "id": "net_ids_or_ips", "text": "Network IDS or IPS deployed", "tags": ["red"] },
+        { "id": "net_anti_spam_malware_solution", "text": "Solution against spam and malware", "tags": [] },
+        { "id": "net_byod_segregated_or_prohibited", "text": "BYOD segregated from internal network or prohibited", "tags": [] },
+        { "id": "net_no_local_admin", "text": "Users do not have local administrative rights", "tags": [] },
+        { "id": "net_vuln_scans", "text": "Network vulnerability scans are performed", "tags": ["red"] },
+        { "id": "net_pentest", "text": "Penetration tests are performed", "tags": [] },
+        { "id": "net_antivirus", "text": "Antivirus software is deployed", "tags": ["red"] },
+        { "id": "net_antimalware", "text": "Anti-malware software is deployed", "tags": [] },
+        { "id": "net_realtime_scanning", "text": "Workstations/servers scanned for viruses in real-time", "tags": ["red"] },
+        { "id": "net_all_endpoints_up_to_date", "text": "All endpoints have up-to-date antivirus, antimalware, and other security software", "tags": ["red"] },
+        { "id": "net_encrypt_in_transit", "text": "Encryption in place for data/credentials in transit", "tags": ["red"] },
+        { "id": "net_encrypt_at_rest", "text": "Encryption enabled for data at rest", "tags": ["red"] },
+        { "id": "net_patch_critical", "text": "Critical vulnerabilities are patched", "tags": ["red"] },
+        { "id": "net_acceptable_use_policy", "text": "Established Acceptable Use Policy", "tags": [] },
+        { "id": "net_info_asset_classification", "text": "Information assets are risk-classified", "tags": ["red"] },
+        { "id": "net_records_retention", "text": "Records retention policy", "tags": [] },
+        { "id": "net_email_attachment_scanning", "text": "Email attachments scanned for viruses/malicious code", "tags": [] },
+        { "id": "net_secure_decommissioning", "text": "Process to remove data/destroy media before decommissioning equipment", "tags": ["red"] },
+        { "id": "net_block_usb_storage", "text": "USB Mass Storage Devices blocked", "tags": [] }
+      ]
+    },
+    "change_mgmt_sdlc": [
+      { "id": "chg_change_mgmt_process", "text": "Documented Change Management process", "tags": [] },
+      { "id": "chg_sdlc", "text": "Established IT Software Development Life Cycle (SDLC)", "tags": [] },
+      { "id": "chg_env_separation", "text": "Separation between dev/test/staging and production", "tags": [] },
+      { "id": "chg_vuln_comm_to_devs", "text": "SDLC includes communicating discovered vulnerabilities to developers", "tags": [] },
+      { "id": "chg_integration_acceptance_testing", "text": "SDLC includes integration and acceptance testing", "tags": [] },
+      { "id": "chg_test_before_prod", "text": "Changes/updates to production systems must be tested before deployment", "tags": [] }
+    ],
+    "remote_workforce": [
+      { "id": "rw_protect_company_customer_info", "text": "Employees must protect proprietary company and customer info", "tags": [] },
+      { "id": "rw_mfa_all_remote", "text": "MFA required to secure all methods of remote access", "tags": [] },
+      { "id": "rw_endpoints_up_to_date", "text": "All endpoints have up-to-date antivirus/antimalware", "tags": [] },
+      { "id": "rw_segregated_entry", "text": "Remote connections are fully segregated entry points (VPN/RDP/etc.)", "tags": [] },
+      { "id": "rw_encrypt_both_ends", "text": "Both remote and target workstations encrypt data in transit and at rest", "tags": [] }
+    ],
+    "incident_response_elements": [
+      "Identification", "Investigation", "Containment", "Recovery", "Remediation", "Lessons Learned"
+    ],
+    "business_continuity": [
+      { "id": "bcp_plan", "text": "Documented Business Continuity Plan", "tags": [] }
+    ]
+  },
+
+  "conditions": {
+    "logical_access_controls": {
+      "enforce_mfa_critical_or_pii_if_company_handles_pii": true,
+      "pii_positive_statements": [
+        "The Company collects, stores, uses, transfers, accesses, protects, and/or secures only consumer PII",
+        "The Company collects, stores, uses, transfers, accesses, protects, and/or secures both consumer PII"
+      ],
+      "passwords_encrypted_in_transit_only_if_negative_statement_present": [
+        "Passwords are not encrypted in transit",
+        "Encryption is not in place for data and credentials in transit"
+      ]
+    },
+    "network_information_security": {
+      "enforce_pii_controls_if_company_handles_pii": true,
+      "do_not_enforce_need_to_know_if_least_privilege_statement_present": true
+    },
+    "remote_workforce": {
+      "enforce_only_if_remote_work_allowed": "The Company allows employees and/or contractors to work remotely"
+    },
+    "change_mgmt_sdlc": {
+      "enforce_sdlc_criteria_only_if_software_provider": true
+    },
+    "cross_satisfaction": [
+      {
+        "if_any_statement_present": ["All endpoints have up-to-date antivirus, antimalware"],
+        "then_mark_controls_met": ["net_all_endpoints_up_to_date", "rw_endpoints_up_to_date"]
+      }
+    ]
+  },
+
+  "ratings": {
+    "very_favorable": {
+      "info_tech_overview": { "required": ["Hardware, software… asset inventory"] },
+      "logical_access_controls": { "required_all": true },
+      "network_information_security": {
+        "pii_controls_required_if_company_handles_pii": true,
+        "controls_required_all": true
+      },
+      "change_mgmt_sdlc": { "required_all": true },
+      "remote_workforce": { "required_all": true },
+      "incident_response": { "min_elements": 4 },
+      "business_continuity": { "required": true }
+    },
+    "favorable": {
+      "info_tech_overview": { "required": ["Hardware, software… asset inventory"] },
+      "logical_access_controls": { "min_count": 8, "must_include_tag": "red" }, 
+      "network_information_security": {
+        "pii_controls_required_if_company_handles_pii": true,
+        "min_count": 15,
+        "must_include_tag": "red"
+      },
+      "change_mgmt_sdlc": {
+        "require_change_mgmt_process": true,
+        "min_count_from": ["chg_sdlc", "chg_env_separation", "chg_vuln_comm_to_devs", "chg_integration_acceptance_testing", "chg_test_before_prod"],
+        "min_count": 4
+      },
+      "remote_workforce": { "min_count": 4 },
+      "incident_response": { "min_elements": 3 },
+      "business_continuity": { "required": true }
+    },
+    "neutral": {
+      "info_tech_overview": { "required": ["Hardware, software… asset inventory"] },
+      "logical_access_controls": { "min_count": 6, "must_include_tag": "red" }, 
+      "network_information_security": {
+        "pii_controls_required_if_company_handles_pii": true,
+        "min_count": 11,
+        "must_include_tag": "red"
+      },
+      "change_mgmt_sdlc": {
+        "require_change_mgmt_process": true,
+        "min_count_from": ["chg_sdlc", "chg_env_separation", "chg_vuln_comm_to_devs", "chg_integration_acceptance_testing", "chg_test_before_prod"],
+        "min_count": 3
+      },
+      "remote_workforce": { "min_count": 3 },
+      "incident_response": { "min_elements": 3 },
+      "business_continuity": { "required": true }
+    },
+    "unfavorable": {
+      "info_tech_overview": { "required": ["Hardware, software… asset inventory"] },
+      "logical_access_controls": { "min_count": 5 },
+      "network_information_security": { "pii_controls_required_if_company_handles_pii": true, "min_count": 10 },
+      "change_mgmt_sdlc": {
+        "require_change_mgmt_process": true,
+        "min_count_from": ["chg_sdlc", "chg_env_separation", "chg_vuln_comm_to_devs", "chg_integration_acceptance_testing", "chg_test_before_prod"],
+        "min_count": 2
+      },
+      "remote_workforce": { "min_count": 2 },
+      "incident_response": { "min_elements": 3 },
+      "business_continuity": { "required": true }
+    },
+    "very_unfavorable": {
+      "rule": "If vendor has fewer than the safeguards for 'unfavorable', rate Very Unfavorable"
+    },
+    "n_a": { "rule": "Not applicable to the vendor’s services/products" },
+    "no_information_provided": { "rule": "Vendor did not provide information" }
+  }
+}

--- a/sample_notes.txt
+++ b/sample_notes.txt
@@ -1,0 +1,43 @@
+The Company allows employees and/or contractors to work remotely.
+All endpoints have up-to-date antivirus, antimalware.
+Access is provisioned… principle of least privilege.
+MFA is required to secure all privileged/admin accounts.
+Access rights and privileges are reviewed at least annually.
+Access rights are reviewed when an employee changes roles.
+Passwords are unique with complexity rules.
+Automatic account lockout occurs.
+Password frequency changes are required at regular intervals.
+Passwords must be encrypted in transit.
+At least 2 parameters used for 2FA/MFA (Passwords, Smart card, Biometrics, Certificates, One-time password devices, ID badges, Rotating authenticator apps).
+Shared credentials are strictly prohibited.
+Network firewall and/or host-based firewall for workstations.
+Network IDS or IPS deployed.
+Network vulnerability scans are performed.
+Penetration tests are performed.
+Antivirus software is deployed.
+Anti-malware software is deployed.
+Workstations/servers scanned for viruses in real-time.
+Encryption in place for data/credentials in transit.
+Encryption enabled for data at rest.
+Critical vulnerabilities are patched.
+Information assets are risk-classified.
+Process to remove data/destroy media before decommissioning equipment.
+All endpoints have up-to-date antivirus, antimalware, and other security software.
+MFA required to secure all methods of remote access.
+Remote connections are fully segregated entry points (VPN/RDP/etc.).
+Both remote and target workstations encrypt data in transit and at rest.
+Employees must protect proprietary company and customer info.
+Documented Change Management process.
+Established IT Software Development Life Cycle (SDLC).
+Separation between dev/test/staging and production.
+SDLC includes communicating discovered vulnerabilities to developers.
+SDLC includes integration and acceptance testing.
+Changes/updates to production systems must be tested before deployment.
+Documented Business Continuity Plan.
+Identification, Investigation, Containment, Recovery, Remediation, Lessons Learned.
+Hardware, software… asset inventory.
+The Company collects, stores, uses, transfers, accesses, protects, and/or secures both consumer PII.
+MFA is required for access to critical systems or consumer PII.
+Consumer PII in transit is protected by encryption.
+Policies and procedures require secure disposal of consumer PII.
+Access to consumer PII is limited based on the need to know.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- replace the previous Python CLI with a Next.js frontend for evaluating analyst notes against the vendor risk catalog
- port the risk evaluation engine to TypeScript so the UI can score controls, context, and rating tiers in the browser
- document the Next.js workflow and update ignored files for Node/Next artifacts

## Testing
- npm install *(fails: registry access returned 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68dbcde814788320b4098657f3c2314b